### PR TITLE
Change regular <a>s to markdown-style links.

### DIFF
--- a/docs/installation/basic_installation.md
+++ b/docs/installation/basic_installation.md
@@ -20,19 +20,19 @@ If you would prefer less automation, or you  already have existing services on y
 
     <p>Using docker, all of SeAT's dependencies is neatly abstracted away from your hosts operating system and does not conflict with any pre-existing software you might have on your server. With a little bit of extra work, Docker installations are also possible on Windows.
     <br><br>
-    If you have either <code>docker</code> or <code>docker-compose</code> already installed on your server, make sure you have the latest versions as detailed on the <a href="/installation/requirements/">requirements</a> page. If you do not have them installed yet, the following script will install them if needed and then download the SeAT <code>docker-compose.yml</code> and <code>.env</code> files to <code>/opt/seat-docker</code> on your server:</p>
+    If you have either <code>docker</code> or <code>docker-compose</code> already installed on your server, make sure you have the latest versions as detailed on the [requirements](/installation/requirements) page. If you do not have them installed yet, the following script will install them if needed and then download the SeAT <code>docker-compose.yml</code> and <code>.env</code> files to <code>/opt/seat-docker</code> on your server:</p>
 
     <pre><code class="bash hljs">bash <(curl -fsSL https://git.io/seat-docker)</code></pre>
 
     <p>Once downloaded, <code>docker-compose up -d</code> is run from that folder to start the SeAT stack. To see this script in action on a fresh Digital Ocean VPS, check out the following asciinema:</p> <script src="https://asciinema.org/a/c0EM0kQnj86JkNX40TBdhA4Ua.js" id="asciicast-c0EM0kQnj86JkNX40TBdhA4Ua" async></script>
 
-    <p>Once the docker installation is complete, you should have SeAT available on the server, listening on port 8080. For more detailed docker related information as well as next steps to configure a web server, please refer to the <a href="/installation/docker_installation/">Manual Installation: Docker</a> section.</p>
+    <p>Once the docker installation is complete, you should have SeAT available on the server, listening on port 8080. For more detailed docker related information as well as next steps to configure a web server, please refer to the [Manual Installation: Docker](/installation/docker_installation) section.</p>
 
-    <p>To configure ESI for SSO and API pulls, please refer to the <a href="/configuration/esi_configuration/">Configuring ESI</a> documentation page</p>
+    <p>To configure ESI for SSO and API pulls, please refer to the [Configuring ESI](/configuration/esi_configuration/) documentation page</p>
 
     <div class="admonition note">
         <p class="admonition-title"> Note</p>
-        <p>Please have a look at <a href="/admin_guides/docker_admin/">Docker Admin</a> Page for commands for Docker.</p>
+        <p>Please have a look at [Docker Admin](/admin_guides/docker_admin) Page for commands for Docker.</p>
     </div>
 
 </div>
@@ -58,7 +58,7 @@ If you would prefer less automation, or you  already have existing services on y
 
     <p>Once the preparations are done, the installer will prompt you to run <code>seat install:production</code>. </p>
 
-    <p>To configure ESI for SSO and API pulls, please refer to the <a href="/configuration/esi_configuration/">Configuring ESI</a> documentation page</p>
+    <p>To configure ESI for SSO and API pulls, please refer to the [Configuring ESI](/configuration/esi_configuration) documentation page</p>
 
 </div>
 </section>


### PR DESCRIPTION
The markdown ones work, but the <a>s don't since they end up not including the "docs" part of the path.